### PR TITLE
just: Check feature matrix in `check`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,32 +1,75 @@
-alias b := build
-alias c := check
-alias f := fmt
-alias t := test
-alias p := pre-push
-
+# Default recipe
 _default:
    @just --list
 
+# ======================== #
+# Aliases                  #
+# ======================== #
+
+alias b := build
+alias c := check
+alias d := doc
+alias f := fmt
+alias m := msrv
+alias p := pre-push
+alias t := test
+
+# ======================== #
+# Toolchains               #
+# ======================== #
+
+# Nightly toolchain
+nightly := 'nightly'
+
+# Stable toolchain
+stable := 'stable'
+
+# MSRV toolchain
+msrv := '1.75.0'
+
+# ======================== #
+# Recipes                  #
+# ======================== #
+
 # Build the project
 build:
-   cargo build
+   cargo +{{stable}} build --all-targets
 
-# Check code: formatting, compilation, linting, and commit signature
-check:
-   cargo +nightly fmt --all -- --check
-   cargo check --all-features --all-targets
-   cargo clippy --all-features --all-targets -- -D warnings
-   @[ "$(git log --pretty='format:%G?' -1 HEAD)" = "N" ] && \
-       echo "\n⚠️  Unsigned commit: BDK requires that commits be signed." || \
-       true
+# Check MSRV
+msrv:
+   cargo +{{msrv}} build --lib --no-default-features
+   cargo +{{msrv}} build --lib --no-default-features --features "28_0"
+   cargo +{{msrv}} build --lib --no-default-features --features "29_0"
+   cargo +{{msrv}} build --lib --no-default-features --features "30_0"
 
 # Format all code
 fmt:
-   cargo +nightly fmt
+   cargo +{{nightly}} fmt
 
-# Run all tests on the workspace with all features
+# Check code: formatting, compilation, linting, and commit signature
+check:
+   @just _verify-head
+   cargo +{{nightly}} fmt --all -- --check
+   cargo +{{stable}} check --all-targets --no-default-features
+   cargo +{{stable}} check --all-targets --no-default-features --features "28_0"
+   cargo +{{stable}} check --all-targets --no-default-features --features "29_0"
+   cargo +{{stable}} check --all-targets --no-default-features --features "30_0"
+   cargo +{{stable}} clippy --all-targets -- -D warnings
+
+# Run all tests on the workspace
 test:
-   cargo test --all-features
+   cargo +{{stable}} test --no-fail-fast
 
-# Run pre-push suite: format, check, and test
-pre-push: fmt check test
+# Run doctests. Build and check docs
+doc:
+   cargo +{{stable}} test --doc
+   RUSTDOCFLAGS='-D warnings' cargo +{{stable}} doc --no-deps
+
+# Run pre-push suite: format, check, test, doc
+pre-push: fmt check test doc
+
+# Verify signed commit
+_verify-head:
+   @[ "$(git log --pretty='format:%G?' -1 HEAD)" = "N" ] && \
+      echo "\n⚠️  Unsigned commit: BDK requires that commits be signed." || \
+      true


### PR DESCRIPTION
## Description

The idea is to have a `cargo check` for every feature configuration in the `check` recipe.

### Notes to the reviewers

I felt that checking `--all-features` didn't really make sense here because the Bitcoin Core features aren't necessarily additive per se, they're more like mutually exclusive. I can see that `corepc-node` does things slightly differently in that each Core version feature enables the previous one, and that's a possibility we could explore. Let me know what you think.