### PR TITLE
refactor(client): Refactor Client::with_auth method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -83,17 +83,11 @@ impl Client {
             .map_err(|e| Error::InvalidUrl(format!("{e}")))?
             .timeout(std::time::Duration::from_secs(60));
 
-        builder = match auth {
-            Auth::UserPass(user, pass) => builder.basic_auth(user, Some(pass)),
-            Auth::CookieFile(path) => {
-                let cookie = std::fs::read_to_string(path)
-                    .map_err(|_| Error::InvalidCookieFile)?
-                    .trim()
-                    .to_string();
-                builder.cookie_auth(cookie)
-            }
-        };
+        let (user, pass) = auth.get_user_pass()?;
 
+        if let Some(username) = user {
+            builder = builder.basic_auth(username, pass);
+        }
         Ok(Self {
             inner: jsonrpc::Client::with_transport(builder.build()),
         })
@@ -307,7 +301,6 @@ mod test_auth {
         let cookie_path = PathBuf::from("/nonexistent/path/to/cookie");
 
         let result = Client::with_auth(dummy_url, Auth::CookieFile(cookie_path));
-
-        assert!(matches!(result, Err(Error::InvalidCookieFile)));
+        assert!(matches!(result, Err(Error::Io(_))));
     }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR simplifies the `Client::auth_with` method to use `Auth::get_user_pass()` instead of a `match` expression for authentication.

Fixes #17 
<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

## Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing