### PR TITLE
Add `sendrawtransaction` and `getblockchaininfo` RPC methods

### DIFF
--- a/src/bitreq.rs
+++ b/src/bitreq.rs
@@ -12,7 +12,9 @@ use std::{
 
 use corepc_types::{
     bitcoin::{
-        Block, BlockHash, Transaction, Txid, block::Header, consensus::encode::deserialize_hex,
+        Block, BlockHash, Transaction, Txid,
+        block::Header,
+        consensus::encode::{deserialize_hex, serialize_hex},
     },
     model, v30,
 };
@@ -226,6 +228,21 @@ impl Client {
         self.call::<String>(Rpc::GetRawTransaction, &[json!(txid)])
             .and_then(|tx_hex| deserialize_hex(&tx_hex).map_err(Error::DecodeHex))
     }
+
+    /// Submits a raw transaction to the network.
+    ///
+    /// # Arguments
+    ///
+    /// * `tx`: The transaction to broadcast.
+    ///
+    /// # Returns
+    ///
+    /// The transaction ID (`Txid`) of the broadcasted transaction.
+    pub fn send_raw_transaction(&self, tx: &Transaction) -> Result<Txid, Error> {
+        let hex_tx = serialize_hex(tx);
+        let txid: Txid = self.call(Rpc::SendRawTransaction, &[json!(hex_tx)])?;
+        Ok(txid)
+    }
 }
 
 #[cfg(feature = "29_0")]
@@ -264,6 +281,16 @@ impl Client {
         let block_info: v30::GetBlockVerboseOne =
             self.call(Rpc::GetBlock, &[json!(block_hash), json!(1)])?;
         block_info.into_model().map_err(Error::model)
+    }
+
+    /// Retrieves information about the blockchain state.
+    ///
+    /// # Returns
+    ///
+    /// State information as a `GetBlockchainInfo` struct.
+    pub fn get_blockchain_info(&self) -> Result<model::GetBlockchainInfo, Error> {
+        let info: v30::GetBlockchainInfo = self.call(Rpc::GetBlockchainInfo, &[])?;
+        info.into_model().map_err(Error::model)
     }
 }
 

--- a/src/bitreq/v28.rs
+++ b/src/bitreq/v28.rs
@@ -5,7 +5,7 @@
 use bitcoin::BlockHash;
 use corepc_types::{
     bitcoin,
-    model::{GetBlockHeaderVerbose, GetBlockVerboseOne},
+    model::{GetBlockHeaderVerbose, GetBlockVerboseOne, GetBlockchainInfo},
     v28,
 };
 use jsonrpc::serde_json::json;
@@ -45,5 +45,15 @@ impl Client {
         let block_info: v28::GetBlockVerboseOne =
             self.call(Rpc::GetBlock, &[json!(block_hash), json!(1)])?;
         block_info.into_model().map_err(Error::model)
+    }
+
+    /// Retrieves information about the blockchain state.
+    ///
+    /// # Returns
+    ///
+    /// State information as a `GetBlockchainInfo` struct.
+    pub fn get_blockchain_info(&self) -> Result<GetBlockchainInfo, Error> {
+        let info: v28::GetBlockchainInfo = self.call(Rpc::GetBlockchainInfo, &[])?;
+        info.into_model().map_err(Error::model)
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -30,6 +30,10 @@ pub enum Rpc {
     GetRawMempool,
     /// `getrawtransaction` — returns raw transaction data for a given txid.
     GetRawTransaction,
+    /// `getblockchaininfo` - returns information about the blockchain state.
+    GetBlockchainInfo,
+    /// `sendrawtransaction` - send raw transaction to the network.
+    SendRawTransaction,
 }
 
 impl core::fmt::Display for Rpc {
@@ -43,6 +47,8 @@ impl core::fmt::Display for Rpc {
             Self::GetBlockHeader => "getblockheader",
             Self::GetRawMempool => "getrawmempool",
             Self::GetRawTransaction => "getrawtransaction",
+            Self::GetBlockchainInfo => "getblockchaininfo",
+            Self::SendRawTransaction => "sendrawtransaction",
         };
         write!(f, "{s}")
     }
@@ -62,5 +68,7 @@ mod tests {
         assert_eq!(Rpc::GetBlockHeader.to_string(), "getblockheader");
         assert_eq!(Rpc::GetRawMempool.to_string(), "getrawmempool");
         assert_eq!(Rpc::GetRawTransaction.to_string(), "getrawtransaction");
+        assert_eq!(Rpc::SendRawTransaction.to_string(), "sendrawtransaction");
+        assert_eq!(Rpc::GetBlockchainInfo.to_string(), "getblockchaininfo");
     }
 }

--- a/tests/rpc_client.rs
+++ b/tests/rpc_client.rs
@@ -5,9 +5,12 @@
 //! These tests require a running Bitcoin Core node in regtest mode. To setup, refer to [`bitcoind`].
 
 use core::str::FromStr;
+use std::collections::BTreeMap;
 
 use bdk_bitcoind_client::bitreq::{Auth, Client};
-use corepc_types::bitcoin::{Amount, BlockHash, Txid};
+use corepc_types::bitcoin::{
+    Amount, BlockHash, Network, Transaction, Txid, absolute, transaction::Version,
+};
 
 mod testenv;
 
@@ -311,4 +314,86 @@ fn test_get_block_filter() {
         .expect("failed to get block filter");
 
     assert!(!result.filter.is_empty());
+}
+
+#[test]
+fn test_get_blockchain_info() {
+    let env = TestEnv::setup().unwrap();
+
+    env.mine_blocks(2, None).expect("failed to mine blocks");
+
+    let blockchain_info = env
+        .client
+        .get_blockchain_info()
+        .expect("failed to get blockchain info");
+
+    assert_eq!(blockchain_info.chain, Network::Regtest);
+    assert!(blockchain_info.blocks >= 2);
+
+    let best_hash = env.client.get_best_block_hash().unwrap();
+    assert_eq!(blockchain_info.best_block_hash, best_hash);
+}
+
+#[test]
+fn test_send_raw_transaction() {
+    let env = TestEnv::setup().unwrap();
+
+    env.mine_blocks(101, None).expect("failed to mine blocks");
+
+    let recipient_address = env.bitcoind.client.new_address().unwrap();
+
+    let mut outputs = BTreeMap::new();
+    outputs.insert(recipient_address, Amount::from_btc(0.001).unwrap());
+
+    let funded_psbt = env
+        .bitcoind
+        .client
+        .wallet_create_funded_psbt(vec![], vec![outputs])
+        .unwrap()
+        .into_model()
+        .unwrap();
+
+    let signed_psbt = env
+        .bitcoind
+        .client
+        .wallet_process_psbt(&funded_psbt.psbt)
+        .unwrap()
+        .into_model()
+        .unwrap();
+
+    assert!(signed_psbt.complete, "PSBT was not completely signed");
+
+    let finalized = env
+        .bitcoind
+        .client
+        .finalize_psbt(&signed_psbt.psbt)
+        .unwrap()
+        .into_model()
+        .unwrap();
+
+    let raw_hex = finalized.psbt.unwrap().extract_tx().unwrap();
+
+    let txid = env
+        .client
+        .send_raw_transaction(&raw_hex)
+        .expect("failed to broadcast transaction");
+
+    let mempool = env.client.get_raw_mempool().expect("failed to get mempool");
+    assert!(mempool.contains(&txid));
+}
+
+#[test]
+fn test_send_raw_transaction_invalid() {
+    let env = TestEnv::setup().unwrap();
+
+    let invalid_tx = Transaction {
+        version: Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![],
+    };
+
+    let result = env.client.send_raw_transaction(&invalid_tx);
+
+    assert!(result.is_err(), "Expected transaction to be rejected");
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR adds the `sendrawtransaction` and `getblockchaininfo` rpc methods to the bitreq module.

Fixes #58 

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

## Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I ran `just pre-push` before committing
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

