### PR TITLE
ci: Update actions deps

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain and configure cache
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
           cache: true

--- a/.github/workflows/commit_signatures.yml
+++ b/.github/workflows/commit_signatures.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   persist-credentials: false
 
@@ -52,7 +52,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,4 +26,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ bitreq = ["dep:corepc-types", "jsonrpc/bitreq_http"]
 28_0 = []
 
 [package.metadata.rbmt.toolchains]
-stable = "1.95.0"
+stable = "1.96.0"
 nightly = "nightly"
 
 [package.metadata.rbmt.test]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ corepc-types = { version = "0.12.0", features = ["default"], optional = true }
 jsonrpc = { version = "0.20.0", default-features = false }
 
 # These pins are needed for `Cargo-minimal.lock`:
-hex-conservative = { version = "0.2.1" } # blame: corepc-node
+hex-conservative = { version = "0.2.1" }
 
 [dev-dependencies]
 anyhow = { version = "1.0.66" }
@@ -24,9 +24,9 @@ bdk_bitcoind_client = { path = ".", default-features = false, features = ["bitre
 bitcoind = { version = "0.38.0", features = ["download", "29_0"] }
 
 # These pins are needed for `Cargo-minimal.lock`:
-tar = { version = "0.4.43" } # blame: corepc-node
-filetime = { version = "0.2.8" } # blame: corepc-node
-log = { version = "0.4.14" } # blame: corepc-node
+tar = { version = "0.4.43" }
+filetime = { version = "0.2.8" }
+log = { version = "0.4.14" }
 
 [features]
 default = ["28_0", "bitreq"]

--- a/rbmt-version
+++ b/rbmt-version
@@ -1,1 +1,1 @@
-cargo-rbmt-0.2.1
+cargo-rbmt-0.5.0


### PR DESCRIPTION
### Description

Bump GitHub Actions dependencies to their latest versions, update the stable Rust toolchain to 1.96.0, upgrade `cargo-rbmt` to 0.5.0, and remove stale `corepc-node` comments from `Cargo.toml` (those deps are now pinned for `bitcoind`). No source or test changes. All CI workflows are pin-by-SHA with version comments.

## Changelog notice

### Changed
- rbmt: bump stable channel to 1.96.0
- rbmt: bump rbmt-version to 0.5.0
- ci: bump `actions/checkout` to v7.0.0
- ci: bump `actions-rust-lang/setup-rust-toolchain` to v1.17.0
- ci: bump `zizmorcore/zizmor-action` to v0.5.7
