### PR TITLE
feat(bitreq): Add Client::with_auth

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -44,7 +44,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bdk_bitcoind_client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bdk_bitcoind_client",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -44,7 +44,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bdk_bitcoind_client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bdk_bitcoind_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.1.0"
+version = "0.2.0"
 name = "bdk_bitcoind_client"
 description = "A minimal `bitcoind` RPC client custom built for BDK"
 authors = ["Bitcoin Dev Kit Developers"]

--- a/justfile
+++ b/justfile
@@ -64,5 +64,5 @@ test:
 test-version VERSION:
     cargo test --no-default-features --features {{VERSION}}
 
-[doc: "Run pre-push suite: lock, check-sigs, fmt, check, test, and msrv"]
-pre-push: lock check-sigs fmt check test msrv
+[doc: "Run pre-push suite: check-sigs, fmt, check, msrv, and test"]
+pre-push: check-sigs fmt check msrv test

--- a/src/bitreq.rs
+++ b/src/bitreq.rs
@@ -8,6 +8,7 @@ use std::{
     fs::File,
     io::{BufRead, BufReader},
     path::PathBuf,
+    time::Duration,
 };
 
 use corepc_types::{
@@ -27,6 +28,9 @@ use crate::{Error, Rpc};
 
 #[cfg(all(feature = "28_0", not(feature = "29_0")))]
 pub mod v28;
+
+/// Request timeout to be used by default if not specified.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Authentication methods for the Bitcoin Core JSON-RPC server.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -73,16 +77,21 @@ impl std::fmt::Debug for Client {
 }
 
 impl Client {
-    /// Creates a client connected to a Bitcoin Core RPC server with authentication and timeout.
+    /// Creates a client connected to a Bitcoin Core RPC server with `auth`.
     ///
     /// # Errors
     ///
     /// Returns an error if the URL is invalid or the cookie file cannot be read.
-    pub fn with_auth_timeout(
-        url: &str,
-        auth: Auth,
-        timeout: core::time::Duration,
-    ) -> Result<Self, Error> {
+    pub fn with_auth(url: &str, auth: Auth) -> Result<Self, Error> {
+        Self::with_auth_timeout(url, auth, DEFAULT_TIMEOUT)
+    }
+
+    /// Creates a client connected to a Bitcoin Core RPC server with `auth` and `timeout`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URL is invalid or the cookie file cannot be read.
+    pub fn with_auth_timeout(url: &str, auth: Auth, timeout: Duration) -> Result<Self, Error> {
         let mut builder = bitreq_http::Builder::new()
             .url(url)
             .map_err(|e| Error::InvalidUrl(format!("{e}")))?

--- a/tests/testenv.rs
+++ b/tests/testenv.rs
@@ -23,7 +23,7 @@ impl TestEnv {
     /// This will first look for the path of the `bitcoind` executable using [`bitcoind::exe_path`]
     /// before returning a new [`TestEnv`] with [`Client`] connected to it.
     ///
-    /// Note that [`Node`] also exposes its own RPC [`client`](Node::client) which may help with
+    /// Note that [`BitcoinD`] also exposes its own RPC [`client`](BitcoinD::client) which may help with
     /// creating different test cases, but be aware that this is different from the client we're
     /// actually testing.
     pub fn setup() -> anyhow::Result<Self> {
@@ -44,7 +44,7 @@ impl TestEnv {
     }
 
     /// Mines `nblocks` blocks to the given `address`, or an address controlled
-    /// by the [`Node`] if not provided.
+    /// by [`BitcoinD`] if not provided.
     pub fn mine_blocks(
         &self,
         nblocks: usize,


### PR DESCRIPTION
### Description

Add `Client::with_auth(url, auth)` as a convenience constructor for the `bitreq` client. Previously, callers were required to supply an explicit `timeout` parameter via `with_auth_timeout`. The new method defaults to a 15-second timeout (`DEFAULT_TIMEOUT`) and delegates to `with_auth_timeout`, so existing code is unaffected.

Clean up `tests/testenv.rs` doc comments, and reorder sub-commands of the `pre-push` recipe.

Bump the version in Cargo.toml to 0.2.0

## Changelog notice

### Added
- `bitreq::Client::with_auth` constructor using a default 15-second timeout

### Changed
- Bump version to `0.2.0`
